### PR TITLE
Update action.yaml to allow devs to use deno v2

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -24,6 +24,10 @@ inputs:
     description: "Folders/files to exclude for deploying"
     required: false
     default: "node_modules"
+  deno_version:
+    description: "The version of Deno to install"
+    required: false
+    default: "v1.x"
 runs:
   using: "composite"
   steps:
@@ -33,7 +37,7 @@ runs:
     - name: Install Deno
       uses: denoland/setup-deno@v1
       with:
-        deno-version: v1.x
+        deno-version: ${{ inputs.deno_version }}
 
     - uses: actions/cache@v3
       if: ${{ inputs.skip_build == 'false' }}


### PR DESCRIPTION
Allow the devs to use deno version 2 in your deploys. This [link](https://github.com/deco-sites/amazarashi/actions/runs/11862355356/job/33061563431) is a exemple of run